### PR TITLE
Fix int overflow occurred in FileDownloadInputStream

### DIFF
--- a/src/main/java/fm/last/moji/impl/FileDownloadInputStream.java
+++ b/src/main/java/fm/last/moji/impl/FileDownloadInputStream.java
@@ -62,7 +62,7 @@ class FileDownloadInputStream extends InputStream {
 
   @Override
   public void close() throws IOException {
-    log.debug("Read {} bytes", delegate.getCount());
+    log.debug("Read {} bytes", delegate.getByteCount());
     try {
       delegate.close();
     } finally {


### PR DESCRIPTION
Fix the exception below:

    Exception in thread "main" java.lang.ArithmeticException: The byte count 5368709120 is too large to be converted to an int
        at org.apache.commons.io.input.CountingInputStream.getCount(CountingInputStream.java:91)
        at fm.last.moji.impl.FileDownloadInputStream.close(FileDownloadInputStream.java:65)


