### PR TITLE
add synchronized block to managedHosts

### DIFF
--- a/src/main/java/fm/last/moji/tracker/pool/MultiHostTrackerPool.java
+++ b/src/main/java/fm/last/moji/tracker/pool/MultiHostTrackerPool.java
@@ -103,8 +103,10 @@ public class MultiHostTrackerPool implements TrackerFactory {
   @Override
   public Set<InetSocketAddress> getAddresses() {
     Set<InetSocketAddress> addresses = new HashSet<InetSocketAddress>();
-    for (ManagedTrackerHost host : managedHosts) {
-      addresses.add(host.getAddress());
+    synchronized (managedHosts) {
+      for (ManagedTrackerHost host : managedHosts) {
+        addresses.add(host.getAddress());
+      }
     }
     return Collections.unmodifiableSet(new HashSet<InetSocketAddress>(addresses));
   }


### PR DESCRIPTION
add synchronized block to managedHosts.

When using jdk8, ConcurrentModificationException was occured.
managedHosts is used by multi threads, but is not synchronized.

```
Caused by: java.util.ConcurrentModificationException: null
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901) [na:1.8.0_40]
        at java.util.ArrayList$Itr.next(ArrayList.java:851) [na:1.8.0_40]
        at fm.last.moji.tracker.pool.MultiHostTrackerPool.getAddresses(MultiHostTrackerPool.java:106) [moji-1.4.0.jar:na]
        at fm.last.moji.impl.Executor.<init>(Executor.java:36) [moji-1.4.0.jar:na]
        at fm.last.moji.impl.MojiFileImpl.<init>(MojiFileImpl.java:57) [moji-1.4.0.jar:na]
        at fm.last.moji.impl.MojiImpl.getFile(MojiImpl.java:53) [moji-1.4.0.jar:na]
        at fm.last.moji.spring.SpringMojiBean.getFile(SpringMojiBean.java:99) [moji-1.4.0.jar:na]
```