### PR TITLE
fix ConcurrentModificationException in fm.last.moji.tracker.pool.MultiHostTrackerPool.getAddresses()

### DIFF
--- a/src/main/java/fm/last/moji/tracker/pool/MultiHostTrackerPool.java
+++ b/src/main/java/fm/last/moji/tracker/pool/MultiHostTrackerPool.java
@@ -23,17 +23,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.pool.KeyedPoolableObjectFactory;
-import org.apache.commons.pool.impl.GenericKeyedObjectPool;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import fm.last.moji.impl.NetworkingConfiguration;
 import fm.last.moji.tracker.Tracker;
 import fm.last.moji.tracker.TrackerException;
 import fm.last.moji.tracker.TrackerFactory;
 import fm.last.moji.tracker.impl.AbstractTrackerFactory;
 import fm.last.moji.tracker.impl.CommunicationException;
+import org.apache.commons.pool.KeyedPoolableObjectFactory;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link fm.last.moji.tracker.TrackerFactory TrackerFactory} implementation that provides a
@@ -229,12 +228,9 @@ public class MultiHostTrackerPool implements TrackerFactory {
   }
 
   private ManagedTrackerHost nextHost() throws TrackerException {
-    ManagedTrackerHost managedHost = null;
-    synchronized (managedHosts) {
-      Collections.sort(managedHosts, HostPriorityOrder.INSTANCE);
-      managedHost = managedHosts.get(managedHosts.size() - 1);
-    }
-    return managedHost;
+
+    return Collections.max(managedHosts, HostPriorityOrder.INSTANCE);
+
   }
 
 }

--- a/src/main/java/fm/last/moji/tracker/pool/MultiHostTrackerPool.java
+++ b/src/main/java/fm/last/moji/tracker/pool/MultiHostTrackerPool.java
@@ -23,16 +23,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.pool.KeyedPoolableObjectFactory;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import fm.last.moji.impl.NetworkingConfiguration;
 import fm.last.moji.tracker.Tracker;
 import fm.last.moji.tracker.TrackerException;
 import fm.last.moji.tracker.TrackerFactory;
 import fm.last.moji.tracker.impl.AbstractTrackerFactory;
 import fm.last.moji.tracker.impl.CommunicationException;
-import org.apache.commons.pool.KeyedPoolableObjectFactory;
-import org.apache.commons.pool.impl.GenericKeyedObjectPool;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * {@link fm.last.moji.tracker.TrackerFactory TrackerFactory} implementation that provides a
@@ -228,9 +229,7 @@ public class MultiHostTrackerPool implements TrackerFactory {
   }
 
   private ManagedTrackerHost nextHost() throws TrackerException {
-
     return Collections.max(managedHosts, HostPriorityOrder.INSTANCE);
-
   }
 
 }


### PR DESCRIPTION
about "moji.getFile() throws ConcurrentModificationException under dozens of clients hit it simultaneously #11".

All unit tests are passed.

The point is that Collections.sort(managedHosts, HostPriorityOrder.INSTANCE) in nextHost() method raises ConcurrentModificationException.
So I use Collections.max(managedHosts, HostPriorityOrder.INSTANCE); instead of "sort()".
"max()" does not modify list itself, and execution cost is small.

I have tested this in my staging environment for two weeks and have no bug.